### PR TITLE
Implement marker import bridge

### DIFF
--- a/.github/workflows/marker-bridge-ci.yml
+++ b/.github/workflows/marker-bridge-ci.yml
@@ -1,0 +1,33 @@
+name: marker-bridge-ci
+on:
+  push:
+    paths:
+      - '**.py'
+      - '.github/workflows/marker-bridge-ci.yml'
+      - 'tests/**'
+      - 'requirements.txt'
+  pull_request:
+    paths:
+      - '**.py'
+      - '.github/workflows/marker-bridge-ci.yml'
+      - 'tests/**'
+      - 'requirements.txt'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -r requirements.txt
+      - run: pytest --cov
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: import-history
+          path: import_history.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.1.15
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        args: ["--strict", "--install-types", "--non-interactive", "--config=mypy.ini"]

--- a/marker_import_bridge.py
+++ b/marker_import_bridge.py
@@ -1,0 +1,160 @@
+"""CLI and utilities to import marker YAML blocks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+from uuid import uuid4
+
+import tomllib
+from pydantic import BaseModel, ValidationError, field_validator
+from ruamel.yaml import YAML
+
+from marker_repair_engine import MarkerRepairEngine
+
+
+def load_config(path: Path) -> Dict[str, Any]:
+    if path.exists():
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+    return {}
+
+
+class YAMLBlockSplitter:
+    """Split raw text into YAML blocks."""
+
+    @staticmethod
+    def split(raw: str) -> List[str]:
+        blocks = re.split(r"^\s*---\s*$", raw, flags=re.M)
+        return [b.strip() for b in blocks if b.strip()]
+
+
+class MarkerBase(BaseModel):  # type: ignore[misc]
+    id: str
+    level: int
+    description: str
+    version: str = "1.0.0"
+    status: str = "draft"
+    author: str = "auto_import"
+
+    @field_validator("level")  # type: ignore[misc]
+    @classmethod
+    def _validate_level(cls, v: int) -> int:
+        if v not in {1, 2, 3, 4}:
+            raise ValueError("level must be between 1 and 4")
+        return v
+
+    @field_validator("id")  # type: ignore[misc]
+    @classmethod
+    def _validate_id(cls, v: str) -> str:
+        if not re.match(r"^[A-Z]{1,3}_.+", v):
+            raise ValueError("invalid id format")
+        return v
+
+
+class MarkerValidator:
+    """Validate YAML blocks against the Marker schema."""
+
+    def __init__(self) -> None:
+        self.yaml = YAML(typ="safe", pure=True)
+
+    def validate(self, text: str) -> Tuple[Dict[str, Any], List[str]]:
+        data = self.yaml.load(text)
+        try:
+            valid = MarkerBase(**data)
+            return valid.model_dump(), []
+        except ValidationError as err:
+            return data, [e["msg"] for e in err.errors()]
+
+
+class MarkerWriter:
+    """Write marker files in YAML and JSON form."""
+
+    def __init__(self, marker_dir: Path, json_dir: Path) -> None:
+        self.marker_dir = marker_dir
+        self.json_dir = json_dir
+        self.yaml = YAML(typ="rt")
+        self.marker_dir.mkdir(parents=True, exist_ok=True)
+        self.json_dir.mkdir(parents=True, exist_ok=True)
+
+    def write(self, data: Dict[str, Any]) -> Tuple[Path, Path]:
+        path = self.marker_dir / f"{data['id']}.yaml"
+        if path.exists():
+            path = self.marker_dir / f"{data['id']}_{uuid4().hex[:6]}.yaml"
+        with open(path, "w", encoding="utf-8") as f:
+            self.yaml.dump(data, f)
+        json_path = self.json_dir / (path.stem + ".json")
+        with open(json_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        return path, json_path
+
+
+class HistoryLogger:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        if not self.path.exists():
+            self.path.write_text("[]", encoding="utf-8")
+
+    def append(self, entry: Dict[str, Any]) -> None:
+        history = json.loads(self.path.read_text(encoding="utf-8"))
+        history.append(entry)
+        self.path.write_text(json.dumps(history, indent=2), encoding="utf-8")
+
+
+def process_blocks(blocks: List[str], cfg: Dict[str, Any]) -> int:
+    paths = cfg.get("paths", {})
+    marker_dir = Path(paths.get("marker_dir", "./markers"))
+    json_dir = Path(paths.get("marker_json_dir", "./markers_json"))
+    logger = HistoryLogger(Path("import_history.json"))
+
+    validator = MarkerValidator()
+    repairer = MarkerRepairEngine(cfg.get("repair", {}))
+    writer = MarkerWriter(marker_dir, json_dir)
+
+    ok = 0
+    failed = 0
+    for block in blocks:
+        data, errors = validator.validate(block)
+        status = "imported"
+        if errors:
+            data, _ = repairer.repair(data)
+            data, errors = validator.validate(YAML().dump(data))
+            status = "fixed"
+        if errors:
+            logger.append({"status": "failed", "errors": errors, "snippet": block})
+            failed += 1
+            continue
+        writer.write(data)
+        logger.append({"status": status, "id": data["id"]})
+        ok += 1
+    print(f"{ok} imported, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stdin", action="store_true")
+    parser.add_argument("--input", type=Path)
+    parser.add_argument(
+        "--config", type=Path, default=Path("~/.frausar_import.toml").expanduser()
+    )
+    args = parser.parse_args(argv)
+
+    if args.stdin:
+        raw = sys.stdin.read()
+    elif args.input:
+        raw = args.input.read_text(encoding="utf-8")
+    else:
+        parser.error("--stdin or --input required")
+
+    cfg = load_config(args.config)
+    blocks = YAMLBlockSplitter.split(raw)
+    return process_blocks(blocks, cfg)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/marker_repair_engine.py
+++ b/marker_repair_engine.py
@@ -1,0 +1,72 @@
+"""Utilities to repair marker data before validation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Tuple
+from dateutil import parser
+
+COMMON_FIELD_FIXES = {
+    "beschreibg": "description",
+    "descr": "description",
+}
+
+LEVEL_PREFIX = {1: "A", 2: "S", 3: "C", 4: "MM"}
+
+
+def _iso_or_none(value: Any) -> str | None:
+    try:
+        return datetime.fromisoformat(str(value)).isoformat()
+    except Exception:
+        try:
+            return parser.parse(str(value)).isoformat()
+        except Exception:
+            return None
+
+
+class MarkerRepairEngine:
+    """Apply automatic fixes to marker dictionaries."""
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        self.auto_fix_typo = True
+        self.auto_fix_dates = True
+        self.fallback_author = "auto_import"
+        if config:
+            self.auto_fix_typo = config.get("auto_fix_typo", True)
+            self.auto_fix_dates = config.get("auto_fix_dates", True)
+            self.fallback_author = config.get("fallback_author", "auto_import")
+
+    def repair(self, data: Dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
+        modified = False
+        if self.auto_fix_typo:
+            for wrong, correct in COMMON_FIELD_FIXES.items():
+                if wrong in data:
+                    data[correct] = data.pop(wrong)
+                    modified = True
+        defaults = {"version": "1.0.0", "status": "draft"}
+        for k, v in defaults.items():
+            if k not in data:
+                data[k] = v
+                modified = True
+        if "author" not in data:
+            data["author"] = self.fallback_author
+            modified = True
+        if self.auto_fix_dates:
+            for key in ("created", "last_modified"):
+                if key in data:
+                    iso = _iso_or_none(data[key])
+                    if iso:
+                        data[key] = iso
+                        modified = True
+        if "level" in data and "id" in data:
+            try:
+                lvl = int(data["level"])
+                expected = LEVEL_PREFIX.get(lvl)
+                if expected:
+                    if not str(data["id"]).startswith(f"{expected}_"):
+                        suffix = str(data["id"]).split("_", 1)[-1]
+                        data["id"] = f"{expected}_{suffix}"
+                        modified = True
+            except Exception:
+                pass
+        return data, modified

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+ruamel.yaml>=0.17
+pydantic>=2.0
+python-dateutil>=2.8
+pytest
+pytest-cov
+black
+ruff
+mypy
+pre-commit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture()  # type: ignore[misc]
+def temp_dirs(tmp_path: Path) -> tuple[Path, Path]:
+    markers = tmp_path / "markers"
+    json_dir = tmp_path / "markers_json"
+    markers.mkdir()
+    json_dir.mkdir()
+    return markers, json_dir

--- a/tests/data/duplicate_ids.yaml
+++ b/tests/data/duplicate_ids.yaml
@@ -1,0 +1,7 @@
+id: A_dup
+level: 1
+description: first
+---
+id: A_dup
+level: 1
+description: second

--- a/tests/data/typo_missing.yaml
+++ b/tests/data/typo_missing.yaml
@@ -1,0 +1,3 @@
+id: A_typo
+level: 1
+beschreibg: Something missing

--- a/tests/data/valid_multi.yaml
+++ b/tests/data/valid_multi.yaml
@@ -1,0 +1,7 @@
+id: A_one
+level: 1
+description: Marker one
+---
+id: S_two
+level: 2
+description: Marker two

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_cli_e2e(tmp_path: Path) -> None:
+    data_file = Path(__file__).parent / "data" / "valid_multi.yaml"
+    cfg = tmp_path / "cfg.toml"
+    (tmp_path / "markers").mkdir()
+    (tmp_path / "markers_json").mkdir()
+    cfg.write_text(
+        """[paths]\nmarker_dir='"""
+        + str(tmp_path / "markers")
+        + "'\nmarker_json_dir='"
+        + str(tmp_path / "markers_json")
+        + "'\n"
+        "",
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [
+            "python",
+            "marker_import_bridge.py",
+            "--input",
+            str(data_file),
+            "--config",
+            str(cfg),
+        ],
+        cwd=Path.cwd(),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "imported" in result.stdout

--- a/tests/test_repair_engine.py
+++ b/tests/test_repair_engine.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from marker_repair_engine import MarkerRepairEngine
+
+
+def test_repair_typo_and_defaults() -> None:
+    data = {"id": "A_t", "level": 1, "beschreibg": "test"}
+    repaired, modified = MarkerRepairEngine().repair(data)
+    assert modified
+    assert repaired["description"] == "test"
+    assert repaired["version"] == "1.0.0"

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from marker_import_bridge import YAMLBlockSplitter
+
+
+def test_splitter() -> None:
+    raw = "a:1\n---\nb:2\n\n---\n\n"
+    blocks = YAMLBlockSplitter.split(raw)
+    assert blocks == ["a:1", "b:2"]

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from marker_import_bridge import MarkerValidator
+
+
+def test_validator_success() -> None:
+    block = "id: A_x\nlevel: 1\ndescription: ok"
+    data, errors = MarkerValidator().validate(block)
+    assert not errors
+    assert data["id"] == "A_x"
+
+
+def test_validator_failure() -> None:
+    block = "id: wrong\nlevel: 5"
+    _, errors = MarkerValidator().validate(block)
+    assert errors

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from marker_import_bridge import MarkerWriter
+
+
+def test_writer(temp_dirs: tuple[Path, Path]) -> None:
+    markers, json_dir = temp_dirs
+    writer = MarkerWriter(markers, json_dir)
+    data = {"id": "A_w", "level": 1, "description": "d"}
+    path, json_path = writer.write(data)
+    assert path.exists()
+    assert json_path.exists()
+    assert Path(json_path).read_text().startswith("{")


### PR DESCRIPTION
## Summary
- add marker importer CLI with validation and repair engine
- implement automatic marker repair helpers
- add test suite for splitter, validator, writer and CLI
- configure mypy/ruff/black in pre-commit
- set up GitHub Action for CI

## Testing
- `pre-commit run --files marker_repair_engine.py marker_import_bridge.py tests/test_splitter.py tests/test_validator.py tests/test_repair_engine.py tests/test_writer.py tests/test_cli_e2e.py tests/conftest.py requirements.txt .pre-commit-config.yaml mypy.ini`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68819cfb39a08322888bf56e70ae6e0f